### PR TITLE
PBI 38 - Integrate Notion

### DIFF
--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -1,0 +1,69 @@
+name: Update Notion Task Status
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+jobs:
+  update-notion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract PBI Number from PR Title
+        run: |
+          PBI_NUMBER=$(echo "${{ github.event.pull_request.title }}" | grep -oE 'PBI [0-9]+' | awk '{print $2}')
+          if [ -z "$PBI_NUMBER" ]; then
+            echo "PBI number not found in PR title"
+            exit 1
+          fi
+          echo "PBI_NUMBER=$PBI_NUMBER" >> $GITHUB_ENV
+
+      - name: Determine Task Status
+        run: |
+          if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            echo "TASK_STATUS=Done" >> $GITHUB_ENV
+          else
+            echo "TASK_STATUS=In Progress" >> $GITHUB_ENV
+          fi
+
+      - name: Get Notion Page ID by PBI Number
+        run: |
+          RESPONSE=$(curl -X POST "https://api.notion.com/v1/databases/${{ secrets.NOTION_DATABASE_ID }}/query" \
+          -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
+          -H "Notion-Version: 2022-06-28" \
+          -H "Content-Type: application/json" \
+          --data '{
+            "filter": {
+              "property": "PBI",
+              "number": {
+                "equals": '${{ env.PBI_NUMBER }}'
+              }
+            }
+          }')
+
+          PAGE_ID=$(echo $RESPONSE | jq -r '.results[0].id')
+
+          if [ "$PAGE_ID" == "null" ]; then
+            echo "Task dengan PBI $PBI_NUMBER tidak ditemukan di Notion"
+            exit 1
+          fi
+
+          echo "PAGE_ID=$PAGE_ID" >> $GITHUB_ENV
+
+      - name: Update Task Status in Notion
+        run: |
+          curl -X PATCH "https://api.notion.com/v1/pages/$PAGE_ID" \
+          -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
+          -H "Notion-Version: 2022-06-28" \
+          -H "Content-Type: application/json" \
+          --data '{
+            "properties": {
+              "Status (Frontend)": {
+                "status": {
+                  "name": "${{ env.TASK_STATUS }}"
+                }
+              }
+            }
+          }'

--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract PBI Number from PR Title
         run: |


### PR DESCRIPTION
### **Deskripsi:**  
PR ini memperbarui workflow GitHub Actions untuk secara otomatis memperbarui status task di Notion berdasarkan judul PR.  

- Mengekstrak **nomor PBI** dari judul PR (misalnya, `PBI X ...`).  
- Mencocokkan **kolom PBI** di Notion untuk menemukan task yang sesuai.  
- Mengubah **status menjadi "In Progress"** saat PR dibuka.  
- Mengubah **status menjadi "Done"** saat PR di-merge.  

### **Perubahan yang Dilakukan:**  
✅ Mengekstrak nomor `PBI X` dari judul PR.  
✅ Menggunakan Notion API untuk mencari task berdasarkan nomor PBI.  
✅ Memperbarui properti **Status (Frontend)** di Notion sesuai dengan event PR.  

### **Cara Pengujian:**  
1. Buat PR dengan judul seperti `PBI 123 Implementasi fitur X`.  
2. Cek apakah task yang sesuai di Notion berubah menjadi **"In Progress"**.  
3. Merge PR dan pastikan status task di Notion berubah menjadi **"Done"**.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated process that synchronizes task statuses in Notion with pull request activity. Now, when a pull request is opened or closed, the associated task status is updated automatically, streamlining workflow management and reducing manual updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->