### PR TITLE
chore: create notion cicd optional

### DIFF
--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -22,6 +22,19 @@ jobs:
             echo "HAS_PBI=true" >> $GITHUB_ENV
           fi
 
+      - name: Post warning comment for missing PBI
+        if: env.HAS_PBI == 'false'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **Warning:** PBI number not found in PR title. Skipping status update.'
+            })
+
       - name: Determine Task Status
         if: env.HAS_PBI == 'true'
         run: |
@@ -51,15 +64,16 @@ jobs:
 
           if [ "$PAGE_ID" == "null" ]; then
             echo "Task dengan PBI $PBI_NUMBER tidak ditemukan di Notion"
-            exit 1
+            echo "TASK_FOUND=false" >> $GITHUB_ENV
+          else
+            echo "PAGE_ID=$PAGE_ID" >> $GITHUB_ENV
+            echo "TASK_FOUND=true" >> $GITHUB_ENV
           fi
 
-          echo "PAGE_ID=$PAGE_ID" >> $GITHUB_ENV
-
       - name: Update Task Status in Notion
-        if: env.HAS_PBI == 'true'
+        if: env.HAS_PBI == 'true' && env.TASK_FOUND == 'true'
         run: |
-          curl -X PATCH "https://api.notion.com/v1/pages/$PAGE_ID" \
+          curl -X PATCH "https://api.notion.com/v1/pages/${{ env.PAGE_ID }}" \
           -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
           -H "Notion-Version: 2022-06-28" \
           -H "Content-Type: application/json" \
@@ -72,3 +86,16 @@ jobs:
               }
             }
           }'
+
+      - name: Post warning comment on PR
+        if: env.HAS_PBI == 'true' && env.TASK_FOUND == 'false'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **Warning:** Task with PBI number ${{ env.PBI_NUMBER }} not found in Notion. Skipping status update.'
+            })

--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -15,12 +15,15 @@ jobs:
         run: |
           PBI_NUMBER=$(echo "${{ github.event.pull_request.title }}" | grep -oE 'PBI [0-9]+' | awk '{print $2}')
           if [ -z "$PBI_NUMBER" ]; then
-            echo "PBI number not found in PR title"
-            exit 1
+            echo "PBI number not found in PR title, skipping Notion update"
+            echo "HAS_PBI=false" >> $GITHUB_ENV
+          else
+            echo "PBI_NUMBER=$PBI_NUMBER" >> $GITHUB_ENV
+            echo "HAS_PBI=true" >> $GITHUB_ENV
           fi
-          echo "PBI_NUMBER=$PBI_NUMBER" >> $GITHUB_ENV
 
       - name: Determine Task Status
+        if: env.HAS_PBI == 'true'
         run: |
           if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
             echo "TASK_STATUS=Done" >> $GITHUB_ENV
@@ -29,6 +32,7 @@ jobs:
           fi
 
       - name: Get Notion Page ID by PBI Number
+        if: env.HAS_PBI == 'true'
         run: |
           RESPONSE=$(curl -X POST "https://api.notion.com/v1/databases/${{ secrets.NOTION_DATABASE_ID }}/query" \
           -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
@@ -53,6 +57,7 @@ jobs:
           echo "PAGE_ID=$PAGE_ID" >> $GITHUB_ENV
 
       - name: Update Task Status in Notion
+        if: env.HAS_PBI == 'true'
         run: |
           curl -X PATCH "https://api.notion.com/v1/pages/$PAGE_ID" \
           -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \


### PR DESCRIPTION
Membuat integrasi Notion dalam CI/CD workflow menjadi opsional, sehingga kegagalan pada proses update Notion tidak akan menyebabkan status Pull Request menjadi merah (failed). Dengan perubahan ini:

- Proses deployment dan review dapat terus berjalan meskipun integrasi dengan Notion mengalami masalah
- Mengurangi blocker pada workflow development tim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the workflow to conditionally update task statuses based on the presence of a valid task identifier. If no identifier is found, the process is gracefully skipped, improving efficiency and error handling. Additionally, warning comments are posted on pull requests when a PBI number is missing or the associated task is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->