### PR TITLE
Fix/hide coordinates conditional display

### DIFF
--- a/__tests__/ItineraryDay.test.tsx
+++ b/__tests__/ItineraryDay.test.tsx
@@ -37,7 +37,7 @@ const mockSection = [
         blockType: 'LOCATION',
         startTime: '2022-04-03T10:00:00Z',
         endTime: '2022-04-03T12:00:00Z',
-        location: 'Bali',
+        location: '0,0',
         price: 100,
         photoUrl: 'https://example.com/photo1.jpg',
         routeToNext: {
@@ -63,7 +63,7 @@ const mockSection = [
         blockType: 'LOCATION',
         startTime: '2022-04-03T14:00:00Z',
         endTime: '2022-04-03T16:00:00Z',
-        location: 'Ubud',
+        location: '0,0',
         price: 150,
         photoUrl: 'https://example.com/photo2.jpg',
         routeToNext: {
@@ -89,7 +89,7 @@ const mockSection = [
         blockType: 'LOCATION',
         startTime: '2022-04-03T17:00:00Z',
         endTime: '2022-04-03T19:00:00Z',
-        location: 'Kuta',
+        location: '0,0',
         price: 200,
         photoUrl: 'https://example.com/photo3.jpg',
         // Last block doesn't have routeToNext
@@ -115,7 +115,7 @@ const mockSection = [
         blockType: 'LOCATION',
         startTime: '2022-04-04T14:00:00Z',
         endTime: '2022-04-04T16:00:00Z',
-        location: 'Los Angeles',
+        location: '0,0',
         price: 200,
         photoUrl: 'https://example.com/photo2.jpg',
       },
@@ -132,7 +132,6 @@ describe('ItineraryDay Component', () => {
   it('renders location details correctly', () => {
     render(<ItineraryDay section={mockSection[0]} />)
     expect(screen.getByText('Block Title 1')).toBeInTheDocument()
-    expect(screen.getByText('Bali')).toBeInTheDocument()
     expect(screen.getByText('Rp100')).toBeInTheDocument()
   })
 
@@ -167,7 +166,6 @@ describe('ItineraryDay Component', () => {
     render(<ItineraryDay section={mockSection[1]} />)
     expect(screen.getByText('Section 2')).toBeInTheDocument()
     expect(screen.getByText('Block Title 2')).toBeInTheDocument()
-    expect(screen.getByText('Los Angeles')).toBeInTheDocument()
     expect(screen.getByText('Rp200')).toBeInTheDocument()
     expect(screen.getByText('Block Description 2')).toBeInTheDocument()
   })

--- a/src/modules/DetailItineraryModule/module-elements/ItineraryDay.tsx
+++ b/src/modules/DetailItineraryModule/module-elements/ItineraryDay.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils'
-import { Clock, MapPin, Tag } from 'lucide-react'
+import { Clock, Tag } from 'lucide-react'
 import { RouteInfo } from './RouteInfo'
 
 export const ItineraryDay = ({ section }: { section: Section }) => {
@@ -13,11 +13,13 @@ export const ItineraryDay = ({ section }: { section: Section }) => {
       {section.blocks.map((block, index) => {
         const isLastBlock = index === section.blocks.length - 1
         const formatTime = (time: string) =>
-          new Date(time).toLocaleTimeString('id-ID', {
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: false,
-          })
+          time
+            ? new Date(time).toLocaleTimeString('id-ID', {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+              })
+            : null
         return (
           <div key={block.id}>
             <div
@@ -32,16 +34,17 @@ export const ItineraryDay = ({ section }: { section: Section }) => {
                     {block.title}
                   </h3>
                   <div className="flex items-center gap-4 md:text-lg text-[#024C98] font-roboto font-medium">
-                    <div className="flex items-center gap-1">
-                      <Clock size={16} /> {formatTime(block.startTime)} -{' '}
-                      {formatTime(block.endTime)}
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Tag size={16} /> Rp{block.price.toLocaleString()}
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <MapPin size={16} /> {block.location}
-                    </div>
+                    {block.startTime && block.endTime && (
+                      <div className="flex items-center gap-1">
+                        <Clock size={16} /> {formatTime(block.startTime)} -{' '}
+                        {formatTime(block.endTime)}
+                      </div>
+                    )}
+                    {block.price > 0 && (
+                      <div className="flex items-center gap-1">
+                        <Tag size={16} /> Rp{block.price.toLocaleString()}
+                      </div>
+                    )}
                   </div>
                   <p className="md:text-lg font-roboto">{block.description}</p>
                 </>
@@ -53,7 +56,6 @@ export const ItineraryDay = ({ section }: { section: Section }) => {
                 <div className="absolute -left-1 bottom-8 w-4 border-t-2 border-[#94A3B8]"></div>
               )}
             </div>
-
             {!isLastBlock && block.routeToNext && (
               <div className="ml-6 my-2">
                 <RouteInfo


### PR DESCRIPTION
## Description
This PR addresses two UI issues in the ItineraryDay component:
1. Removes coordinate display that was previously showing with the MapPin icon
2. Makes time and price sections conditionally render only when they contain actual data

## Changes
- Removed location/coordinates display and MapPin icon
- Added conditional rendering for time section (only shows when both startTime and endTime exist)
- Modified price section to only display when price > 0
- Removed unused import for MapPin

## Testing
- Verified component renders correctly with and without time data
- Verified price section only appears when price > 0
- Confirmed coordinates no longer appear in the UI

Fixes #85 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Itinerary displays now conditionally show time details only when complete information is available.
  - Pricing tags appear only for items with a cost, avoiding unnecessary clutter.
  - The location indicator has been removed for a cleaner itinerary view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->