### PR TITLE
Fix location input toggle issue and improve block spacing

### DIFF
--- a/src/modules/ItineraryMakerModule/module-elements/AutocompleteInput.tsx
+++ b/src/modules/ItineraryMakerModule/module-elements/AutocompleteInput.tsx
@@ -55,16 +55,12 @@ function AutocompleteInput({
   }, [title, setValue])
 
   const handleSelect = async (address: string, formattedValue: string) => {
-    console.log('🧠 handleSelect called with', address, formattedValue)
-
     setValue(formattedValue, false)
     clearSuggestions()
 
     const results = await getGeocode({ address })
     const { lat, lng } = getLatLng(results[0])
-    console.log('✅ Calling updateBlock with location')
     updateBlock(blockId, 'location', `${lat},${lng}`)
-    toggleInput(blockId, 'location')
     updateBlock(blockId, 'title', formattedValue)
   }
 

--- a/src/modules/ItineraryMakerModule/module-elements/ItineraryBlock.tsx
+++ b/src/modules/ItineraryMakerModule/module-elements/ItineraryBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -10,11 +10,10 @@ import {
   type DraggableStateSnapshot,
 } from '@hello-pangea/dnd'
 import { X, GripVertical, OctagonAlert } from 'lucide-react'
-import { FeedbackItem, type Block } from '../interface'
+import { type FeedbackItem, type Block } from '../interface'
 import { TimeInput } from './TimeInput'
 import { PriceInput } from './PriceInput'
 import { RouteInfo } from './RouteInfo'
-import { CoordinateInput } from './CoordinateInput'
 import { feedbackForField } from '../utils'
 import { TooltipField } from './TooltipField'
 
@@ -97,7 +96,7 @@ export const ItineraryBlock: React.FC<ItineraryBlockProps> = ({
           <Card
             ref={provided.innerRef}
             {...provided.draggableProps}
-            className={`${snapshot.isDragging ? 'shadow-lg' : ''} ${
+            className={`${!showRoute || !routeInfo ? 'mb-2 md:mb-4' : ''} ${snapshot.isDragging ? 'shadow-lg' : ''} ${
               timeWarning && timeWarning.blockId === block.id
                 ? 'border-red-500'
                 : ''


### PR DESCRIPTION
This PR addresses a bug in the location autocomplete functionality where changing an existing location would clear the route data. It also includes a minor UI improvement for itinerary block spacing.

## Changes
### Bug Fix:

- Removed the toggleInput(blockId, 'location') call from the handleSelect function in AutocompleteInput.tsx component
- Removed debug console.log statements from the same function

## UI Enhancement:

- Added conditional margin styling to itinerary blocks when routes are not shown

## Testing

- Verified that changing locations now works without clearing the route
- Confirmed that block spacing is appropriate with and without routes

Fixes #96 