### PR TITLE
refactor: add minimum height to droppable containers for empty sections

### DIFF
--- a/src/modules/ItineraryMakerModule/sections/ItinerarySections.tsx
+++ b/src/modules/ItineraryMakerModule/sections/ItinerarySections.tsx
@@ -20,7 +20,7 @@ import {
   ChevronDown,
   Trash,
 } from 'lucide-react'
-import { FeedbackItem, type Block, type Section } from '../interface'
+import { type FeedbackItem, type Block, type Section } from '../interface'
 import { type TransportMode } from '@/utils/maps'
 import { ItineraryBlock } from '../module-elements/ItineraryBlock'
 
@@ -151,7 +151,11 @@ export const ItinerarySections: React.FC<ItinerarySectionsProps> = ({
           </div>
           <Droppable droppableId={`section-${section.sectionNumber}`}>
             {(provided: DroppableProvided) => (
-              <div ref={provided.innerRef} {...provided.droppableProps}>
+              <div
+                className="min-h-px"
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+              >
                 {section.blocks?.map((block, blockIndex) => (
                   <ItineraryBlock
                     key={`block-${section.sectionNumber}-${blockIndex}`}


### PR DESCRIPTION
## Description
This PR fixes the issue where users cannot drag blocks to empty sections in the itinerary builder. By adding a minimum height to the droppable container, we ensure that empty sections remain valid drop targets.

## Changes
- Added `min-h-px` class to the droppable container div to maintain a minimum height when empty

## How to test
1. Create two sections in the itinerary builder
2. Add blocks to only one section
3. Try to drag a block from the populated section to the empty section
4. Verify that the block can now be dropped into the empty section

## Related issue
Fixes #105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the appearance of draggable sections by enhancing the visual styling of drop zones, contributing to a more polished and consistent user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->