### PR TITLE
Spike: Add Infisical initial setup

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-    "workspaceId": "ab8a4af0-ea6f-46cc-9fa7-51adb6d1786c",
-    "defaultEnvironment": "dev",
-    "gitBranchToEnvironmentMapping": null
+  "workspaceId": "ab8a4af0-ea6f-46cc-9fa7-51adb6d1786c",
+  "defaultEnvironment": "dev",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "ab8a4af0-ea6f-46cc-9fa7-51adb6d1786c",
+    "defaultEnvironment": "dev",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "husky",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage"
+    "test:cov": "jest --coverage",
+    "infisical:dev": "infisical run -- pnpm run dev"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",


### PR DESCRIPTION
## feat: integrate Infisical secret management

**Summary:**
- Initialize Infisical in the project (`infisical.json` added)
- Add custom script to run the app with Infisical secrets injected using `infisical run -- pnpm run dev`

**Details:**
- `infisical.json` configures the workspace and environment mapping
- Team members can now access secrets easily by:
  ```bash
  infisical login
  infisical run -- pnpm run dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new configuration file for environment management settings.
  - Introduced a new development script for running the app with environment management integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->