### PR TITLE
fix: remove duplicate content in share itinerary modal

### DIFF
--- a/src/modules/DetailItineraryModule/module-elements/ItineraryHeader.tsx
+++ b/src/modules/DetailItineraryModule/module-elements/ItineraryHeader.tsx
@@ -243,22 +243,18 @@ export const ItineraryHeader = ({
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle className="text-2xl text-center w-full font-semibold">
-              Share Itinerary Ini Share Itinerary Ini
+              Share Itinerary Ini
             </DialogTitle>
           </DialogHeader>
           <div className="text-sm text-center text-gray-600">
             Copy dan kirim link dibawah ini. Orang yang mempunyai link dapat
-            melihat, tetapi tidak bisa edit maupun duplikat Copy dan kirim link
-            dibawah ini. Orang yang mempunyai link dapat melihat, tetapi tidak
-            bisa edit maupun duplikat
+            melihat, tetapi tidak bisa edit maupun duplikat
           </div>
           <div className="flex items-center gap-2 mt-4 bg-gray-100 rounded-md p-2">
             <span className="text-sm text-gray-800 truncate w-[300px]">
               {shareLink}
             </span>
-            <span className="text-sm text-gray-800 truncate w-[300px]">
-              {shareLink}
-            </span>
+
             <Button
               className="px-4 py-2 bg-gradient-to-r from-[#016CD7] to-[#014285] text-white items-center rounded"
               onClick={() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed duplicated text and redundant share link in the share itinerary dialog for improved clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->