### PR TITLE
Fix: Hide Transaction Tab when viewing other's profile

### DIFF
--- a/__tests__/ProfileModule.test.tsx
+++ b/__tests__/ProfileModule.test.tsx
@@ -81,6 +81,29 @@ jest.mock('@/components/ui/tabs', () => ({
   }) => <button data-testid={`tab-${value}`}>{children}</button>,
 }))
 
+const mockUser = {
+  id: 'user-123',
+  firstName: 'Test',
+  lastName: 'User',
+  email: 'test@example.com',
+  photoProfile: 'https://example.com/photo.jpg',
+}
+
+const mockAuthContext = {
+  user: mockUser,
+  isAuthenticated: true,
+  setIsAuthenticated: jest.fn(),
+  validate: jest.fn(),
+  preRegistLogin: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  getMe: jest.fn(),
+}
+
+jest.mock('../src/contexts/AuthContext', () => ({
+  useAuthContext: () => mockAuthContext,
+}))
+
 describe('ProfileModule', () => {
   const mockProfile: ProfileProps = {
     id: '1',

--- a/src/modules/ProfileModule/index.tsx
+++ b/src/modules/ProfileModule/index.tsx
@@ -6,10 +6,12 @@ import { ItinerariesSection } from './sections/ItinerariesSection'
 import { LikedItinerariesSection } from './sections/LikedItinerariesSection'
 import { ProfileModuleProps } from './interface'
 import { TransactionSection } from './sections/TransactionSection'
+import { useAuthContext } from '@/contexts/AuthContext'
 
 export default function ProfileModule({
   profile,
 }: Readonly<ProfileModuleProps>) {
+  const { user } = useAuthContext()
   return (
     <div className="min-h-screen container mx-auto max-w-screen-xl px-3 pt-28 sm:pt-32 md:pt-40">
       <ProfileHeader {...profile} />
@@ -17,7 +19,9 @@ export default function ProfileModule({
         <TabsList className="mt-2 sm:mt-4 md:mt-8 w-full md:w-auto">
           <TabsTrigger value="itineraries">Itineraries</TabsTrigger>
           <TabsTrigger value="likedItineraries">Itinerary disukai</TabsTrigger>
-          <TabsTrigger value="transaction">Transaksi</TabsTrigger>
+          {user?.id === profile.id && (
+            <TabsTrigger value="transaction">Transaksi</TabsTrigger>
+          )}
         </TabsList>
         <TabsContent value="itineraries">
           <ItinerariesSection profile={profile} />

--- a/src/modules/ProfileModule/sections/TransactionSection.tsx
+++ b/src/modules/ProfileModule/sections/TransactionSection.tsx
@@ -9,9 +9,7 @@ import { customFetch } from '@/utils/newCustomFetch'
 import { toast } from 'sonner'
 import TransactionCard from '../module-elements/ItineraryCard/TransactionCard'
 
-export const TransactionSection: React.FC<ProfileModuleProps> = ({
-  profile,
-}) => {
+export const TransactionSection: React.FC<ProfileModuleProps> = () => {
   const [transactions, setTransactions] = useState<TransactionProps[]>([])
   const [loading, setLoading] = useState<boolean>(true)
 
@@ -19,7 +17,7 @@ export const TransactionSection: React.FC<ProfileModuleProps> = ({
     try {
       setLoading(true)
       const response = await customFetch<GetTransactionProps>(
-        `/profile/${profile.id}/transactions`
+        `/profile/transactions`
       )
 
       if (response.statusCode !== 200) {


### PR DESCRIPTION
CHANGES:
- Transaction tab only shown when viewing user's self profile
- Endpoint call address to backend API has been changed accordingly

PREV:
![image](https://github.com/user-attachments/assets/ea7ef36b-e603-43b7-9e36-1c2aa26a1a83)

NOW:
![image](https://github.com/user-attachments/assets/9c2e816a-0375-4e4e-9470-acea320d8dc1)

Note: 
- Screenshots are taken when viewing other's profile
- Tests have been modified and checked to cover 100% of the modified code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Transaksi" tab in the profile section is now visible only to the profile owner.

- **Bug Fixes**
  - Transaction data in the profile section now loads from a generic endpoint, ensuring accurate display for the authenticated user.

- **Tests**
  - Improved test coverage for authentication scenarios in the profile module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->