### PR TITLE
Merge pull request #228 from Mutari-App/development

refactor: change image upload size limit to 1 MB for itinerary header and 512 KB for photo profile

### DIFF
--- a/src/modules/ItineraryMakerModule/module-elements/settingsModal.tsx
+++ b/src/modules/ItineraryMakerModule/module-elements/settingsModal.tsx
@@ -147,7 +147,7 @@ export const SettingsItineraryModal: React.FC<SettingsItineraryModalProps> = ({
                 options={{
                   clientAllowedFormats: ['image'],
                   maxFiles: 1,
-                  maxFileSize: 1024 * 256, // 256 KB
+                  maxFileSize: 1024 * 1024, // 1 MB
                 }}
               >
                 Ganti foto cover

--- a/src/modules/ProfileModule/sections/ProfileHeader.tsx
+++ b/src/modules/ProfileModule/sections/ProfileHeader.tsx
@@ -121,7 +121,7 @@ export const ProfileHeader: React.FC<ProfileProps> = ({
             options={{
               clientAllowedFormats: ['image'],
               maxFiles: 1,
-              maxFileSize: 1024 * 256, // 256 KB
+              maxFileSize: 1024 * 512, // 512 KB
             }}
           >
             Pilih Foto


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased maximum file size for cover image uploads in itinerary settings to 1 MB.
  - Increased maximum file size for profile photo uploads to 512 KB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->